### PR TITLE
Update README.md.default

### DIFF
--- a/README.md.default
+++ b/README.md.default
@@ -36,7 +36,7 @@
 2.  Install
 
         $ ddev start
-        $ ddev import-db path/to/backup.sql
+        $ ddev import-db < path/to/backup.sql
         $ nvm use
         $ npm ci
         $ npm run dev


### PR DESCRIPTION
The `ddev import-db` command expects a `-f, --file` attribute for the the .sql dump. 

```
Examples:
  $ ddev import-db
  $ ddev import-db --file=.tarballs/junk.sql
  $ ddev import-db --file=.tarballs/junk.sql.gz
  $ ddev import-db --database=other_db --file=.tarballs/db.sql.gz
  $ ddev import-db --file=.tarballs/db.sql.bz2
  $ ddev import-db --file=.tarballs/db.sql.xz
  $ ddev import-db < db.sql
  $ ddev import-db my-project < db.sql
  $ gzip -dc db.sql.gz | ddev import-db
  ```

Running `ddev import-db` prompts the user for a file path, which is another valid solution, but choosing the easier to understand option for the instructions.