### PR TITLE
Entry type filters for Matrix fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Release notes for Miranj's Craft Boilerplate starter project.
 
 ### Craft
 
+- Added a Matrix field entry type filter, so a single Matrix field can offer different blocks in different sections or global sets.
 - Improved performance of accessing manifest files for cache busting build file URLs.
 - Moved configuration of build stylesheets, build scripts, and external stylesheets to `config/custom`.
 - Added `headLinkTags` to `config/custom` to configure custom `<link>` tags inside `<head>`.

--- a/src/Module.php
+++ b/src/Module.php
@@ -177,7 +177,8 @@ class Module extends \yii\base\Module
             EntryIndexQueryBehavior::class;
     }
 
-    // Register custom entry types filter for matrix fields.
+    // Register custom entry types filter for matrix fields retunred by
+    // `src/filters/EntryTypeFilter.php` - `getHiddenBlocksConfig()`.
     public function onRegisterMatrixFilterEntryTypes(
         DefineEntryTypesForFieldEvent $event,
     ) {

--- a/src/Module.php
+++ b/src/Module.php
@@ -4,14 +4,18 @@ namespace boilerplate;
 
 use Craft;
 use craft\elements\Entry;
+use craft\elements\GlobalSet;
 use boilerplate\behaviors\EntryIndexQueryBehavior;
 use boilerplate\behaviors\IndexEntryBehaviors;
 use boilerplate\behaviors\SectionIndexBehavior;
+use boilerplate\filters\EntryTypeFilter;
 use boilerplate\twig\Extension;
 use craft\models\Section;
 use craft\base\Element;
 use craft\elements\db\EntryQuery;
 use craft\events\DefineBehaviorsEvent;
+use craft\events\DefineEntryTypesForFieldEvent;
+use craft\fields\Matrix;
 use craft\web\Response;
 use yii\base\Event;
 use craft\validators\DateCompareValidator;
@@ -173,6 +177,39 @@ class Module extends \yii\base\Module
             EntryIndexQueryBehavior::class;
     }
 
+    // Register custom entry types filter for matrix fields.
+    public function onRegisterMatrixFilterEntryTypes(
+        DefineEntryTypesForFieldEvent $event,
+    ) {
+        $field = $event->sender;
+        $element = $event->element;
+
+        if (!($element instanceof Entry or $element instanceof GlobalSet)) {
+            return;
+        }
+
+        $elementHandle =
+            $element instanceof Entry
+                ? $element->section?->handle ?? ''
+                : ($element instanceof GlobalSet
+                    ? $element->handle
+                    : '');
+
+        $filterBlocks = EntryTypeFilter::shouldFilterBlocks(
+            $field->handle,
+            $elementHandle,
+            $element,
+        );
+
+        if ($filterBlocks) {
+            $event->entryTypes = EntryTypeFilter::getAllowedBlocks(
+                $event->entryTypes,
+                $elementHandle,
+                $field->handle,
+            );
+        }
+    }
+
     // define custom Section properties
     public function onSectionDefineBehaviors(DefineBehaviorsEvent $event)
     {
@@ -215,6 +252,11 @@ class Module extends \yii\base\Module
         Event::on(Section::class, Section::EVENT_DEFINE_BEHAVIORS, [
             $this,
             'onSectionDefineBehaviors',
+        ]);
+
+        Event::on(Matrix::class, Matrix::EVENT_DEFINE_ENTRY_TYPES, [
+            $this,
+            'onRegisterMatrixFilterEntryTypes',
         ]);
     }
 }

--- a/src/filters/EntryTypeFilter.php
+++ b/src/filters/EntryTypeFilter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace boilerplate\filters;
+
+use craft\elements\Entry;
+use craft\elements\GlobalSet;
+
+// Filter for available matrix field blocks for entries and globals
+class EntryTypeFilter
+{
+    /**
+     * Provides hidden blocks for matrix field context
+     *
+     *intended output:
+     * Array (hidden blocks)
+     */
+    public static function getHiddenBlocksConfig(): array
+    {
+        return [];
+    }
+
+    /**
+     * Determines whether blocks should be filtered
+     *
+     * input:
+     * Field handle
+     * Section or Globalset handle
+     * Entry or Globalset event element
+     *
+     *intended output:
+     * Boolean (true or false)
+     */
+    public static function shouldFilterBlocks(
+        string $fieldHandle = '',
+        string $elementHandle = '',
+        $element = null,
+    ): bool {
+        if (!$fieldHandle || !$elementHandle || !$element) {
+            return false;
+        }
+
+        if (!($element instanceof Entry or $element instanceof GlobalSet)) {
+            return false;
+        }
+
+        $builderHiddenBlocks = self::getHiddenBlocksConfig();
+
+        return isset($builderHiddenBlocks[$fieldHandle][$elementHandle]);
+    }
+
+    /**
+     * Returns allowed blocks for a matrix field based on context
+     *
+     * input:
+     * Array of block handles
+     * Section or Globalset handle
+     * Field handle
+     *
+     *intended output:
+     * Array (of allowed block handles)
+     */
+    public static function getAllowedBlocks(
+        array $allBlocks = [],
+        string $section = '',
+        string $field = '',
+    ): array {
+        $hiddenBlocks = self::getHiddenBlocksConfig()[$field][$section] ?? [];
+        return array_diff($allBlocks, $hiddenBlocks);
+    }
+}

--- a/src/filters/EntryTypeFilter.php
+++ b/src/filters/EntryTypeFilter.php
@@ -5,7 +5,13 @@ namespace boilerplate\filters;
 use craft\elements\Entry;
 use craft\elements\GlobalSet;
 
-// Filter for available matrix field blocks for entries and globals
+/**
+ * Class EntryTypeFilter
+ *
+ * Only works on Matrix fields set to View Mode as `Blocks`.
+ * `Cards`, `Card grid`, and `Index` views bypass `EVENT_DEFINE_ENTRY_TYPES`
+ * while building their `Add New` menu items.
+ */
 class EntryTypeFilter
 {
     /**

--- a/src/filters/EntryTypeFilter.php
+++ b/src/filters/EntryTypeFilter.php
@@ -8,9 +8,13 @@ use craft\elements\GlobalSet;
 /**
  * Class EntryTypeFilter
  *
- * Only works on Matrix fields set to View Mode as `Blocks`.
+ * ⚠️ Only works on Matrix fields set to View Mode as `Blocks`.
  * `Cards`, `Card grid`, and `Index` views bypass `EVENT_DEFINE_ENTRY_TYPES`
  * while building their `Add New` menu items.
+ *
+ * This exists for legacy projects that previously relied on MatrixMate for
+ * per-context block restrictions. New projects don't need it - these
+ * [changes](https://github.com/miranj/craft-boilerplate/pull/154/changes) should be deleted.
  */
 class EntryTypeFilter
 {
@@ -19,6 +23,20 @@ class EntryTypeFilter
      *
      *intended output:
      * Array (hidden blocks)
+     * ```
+     *     [
+     *         'fieldHandle' => [
+     *             'sectionHandle' => [
+     *                 'blockHandle1',
+     *                 'blockHandle2',
+     *             ],
+     *             'globalSetHandle' => [
+     *                 'blockHandle1',
+     *                 'blockHandle2',
+     *             ],
+     *         ],
+     *     ]
+     * ```
      */
     public static function getHiddenBlocksConfig(): array
     {


### PR DESCRIPTION
Closes [Include entry type filter for Craft 5](https://app.asana.com/1/1158496955069020/project/1203079866666008/task/1211947699746003?focus=true)

This filter applies only when the View Mode of the Matrix field is `Blocks`.

- [x] Added CHANGELOG.md entry

